### PR TITLE
Bug fix in hbConfig setup

### DIFF
--- a/src/main/java/org/apache/storm/hbase/trident/state/HBaseState.java
+++ b/src/main/java/org/apache/storm/hbase/trident/state/HBaseState.java
@@ -105,7 +105,7 @@ public class HBaseState implements State {
                 LOG.warn("No 'hbase.rootdir' value found in configuration! Using HBase defaults.");
             }
             for (String key : conf.keySet()) {
-                hbConfig.set(key, String.valueOf(map.get(key)));
+                hbConfig.set(key, String.valueOf(conf.get(key)));
             }
         }
 


### PR DESCRIPTION
Fixed a bug where config values from storm conf map are not being transferred over to hbConfig object correctly.
