### PR TITLE
Fix failing when the column value is null

### DIFF
--- a/src/main/java/org/apache/storm/hbase/bolt/mapper/SimpleHBaseMapper.java
+++ b/src/main/java/org/apache/storm/hbase/bolt/mapper/SimpleHBaseMapper.java
@@ -77,12 +77,18 @@ public class SimpleHBaseMapper implements HBaseMapper {
         if(this.columnFields != null){
             // TODO timestamps
             for(String field : this.columnFields){
-                cols.addColumn(this.columnFamily, field.getBytes(), toBytes(tuple.getValueByField(field)));
+            	Object value = tuple.getValueByField(field);
+            	if(value != null) {
+            		cols.addColumn(this.columnFamily, field.getBytes(), toBytes(value));
+            	}
             }
         }
         if(this.counterFields != null){
             for(String field : this.counterFields){
-                cols.addCounter(this.columnFamily, field.getBytes(), toLong(tuple.getValueByField(field)));
+            	Object value = tuple.getValueByField(field);
+            	if(value != null) {
+            		cols.addCounter(this.columnFamily, field.getBytes(), toLong(tuple.getValueByField(field)));
+            	}
             }
         }
         return cols;


### PR DESCRIPTION
In a lot of cases, a tuple may have incomplete data. Even though a field
may be defined the ColumnFields, a corresponding value may be missing.
Adding a check on the value before converting to bytes.
